### PR TITLE
Fix function undefined in Unity WebGL build

### DIFF
--- a/Plugins/WebGL/JSFileUploader.jslib
+++ b/Plugins/WebGL/JSFileUploader.jslib
@@ -19,7 +19,7 @@ mergeInto(LibraryManager.library,
                     var files = e.target.files;
 
                     if (files.length === 0) {
-                        ResetFileLoader();
+                        _ResetFileLoader();
                         return;
                     }
 
@@ -38,7 +38,7 @@ mergeInto(LibraryManager.library,
             var fileuploader = document.getElementById('fileuploader');
 
             if (fileuploader === null)
-                InitFileLoader(FileCallbackObjectName, FileCallbackMethodName);
+                _InitFileLoader(FileCallbackObjectName, FileCallbackMethodName);
 
             if (str !== null || str.match(/^ *$/) === null)
                 fileuploader.setAttribute('accept', str);


### PR DESCRIPTION
# Explain
When building Unity WebGL, functions in jslib will have an underscore prefix added after being processed by Emscripten. Therefore, if you need to call other functions within jslib, you must adjust the function names accordingly.

# Steps to reproduce
1. Call InitFileLoader to initialize.
2. Call RequestUserFile to let the user upload a file.
3. Call RequestUserFile again, but click the cancel button in the popup dialog.

**ResetFileLoader is not defined**
![image](https://github.com/AlexMorOR/Unity-UserFileUploader/assets/65897020/1441c50f-c758-4714-a16a-98dbab90d99a)

**The function name has been prefixed with an underscore**
![image](https://github.com/AlexMorOR/Unity-UserFileUploader/assets/65897020/f90a42a5-4dae-4c32-a7f1-1c60964bf4fa)

# Reference
https://forum.unity.com/threads/browser-scripting-and-function-calling.477716/
https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html